### PR TITLE
gemspec: switch summary and description

### DIFF
--- a/spy.gemspec
+++ b/spy.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
   gem.authors       = ["Ryan Ong"]
   gem.email         = ["ryanong@gmail.com"]
-  gem.description   = %q{A simple modern mocking library that uses the spy pattern and checks method's existence and arity.}
-  gem.summary       = %q{Spy is a mocking library that was made for the modern age. It supports only 1.9.3+. Spy by default will raise an error if you attempt to stub a method that doesn't exist or call the stubbed method with the wrong arity.}
+  gem.summary       = %q{A simple modern mocking library that uses the spy pattern and checks method's existence and arity.}
+  gem.description   = %q{Spy is a mocking library that was made for the modern age. It supports only 1.9.3+. Spy by default will raise an error if you attempt to stub a method that doesn't exist or call the stubbed method with the wrong arity.}
   gem.homepage      = "https://github.com/ryanong/spy"
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
The `summary` variable in the gemspec is intended to be a small bit of text that presents the purpose of the gem in a short "at a glance" format

The `description` variable is a longer characterization of the gem.

The two settings were reversed in the gemspec, and this pull request flips them.