### PR TITLE
Optimize Spy::Subrouting#get_spy_id

### DIFF
--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -365,14 +365,12 @@ module Spy
 
       # @private
       def get_spy_id(method)
-        return nil unless method.parameters[0].is_a?(Array) &&
-                          (raw_id = method.parameters[0][1]) &&
-                          raw_id.to_s.start_with?(SPY_ARGS_PREFIX)
-
-        slice_length = raw_id.length - SPY_ARGS_PREFIX.length
-        id = raw_id.slice(SPY_ARGS_PREFIX.length, slice_length)
-
-        id.to_i
+        if method.parameters[0].is_a?(Array) && method.parameters[0][1]
+          raw_id = method.parameters[0][1].to_s
+          if raw_id.start_with?(SPY_ARGS_PREFIX)
+            raw_id[SPY_ARGS_PREFIX.length..-1].to_i
+          end
+        end
       end
     end
   end

--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -222,11 +222,12 @@ module Spy
     # this returns a lambda that calls the spy object.
     # we use eval to set the spy object id as a parameter so it can be extracted
     # and looked up later using `Method#parameters`
+    SPY_ARGS_PREFIX='__spy_args_'.freeze
     def override_method
       eval <<-METHOD, binding, __FILE__, __LINE__ + 1
       __method_spy__ = self
-      lambda do |*__spy_args_#{self.object_id}, &block|
-        __method_spy__.invoke(self, __spy_args_#{self.object_id}, block, caller(1)[0])
+      lambda do |*#{SPY_ARGS_PREFIX}#{self.object_id}, &block|
+        __method_spy__.invoke(self, #{SPY_ARGS_PREFIX}#{self.object_id}, block, caller(1)[0])
       end
       METHOD
     end
@@ -364,9 +365,14 @@ module Spy
 
       # @private
       def get_spy_id(method)
-        return nil unless method.parameters[0].is_a?(Array)
-        id = method.parameters[0][1].to_s.sub!("__spy_args_", "")
-        id.to_i if id
+        return nil unless method.parameters[0].is_a?(Array) &&
+                          (raw_id = method.parameters[0][1]) &&
+                          raw_id.to_s.start_with?(SPY_ARGS_PREFIX)
+
+        slice_length = raw_id.length - SPY_ARGS_PREFIX.length
+        id = raw_id.slice(SPY_ARGS_PREFIX.length, slice_length)
+
+        id.to_i
       end
     end
   end


### PR DESCRIPTION
Improves parsing of the spy id by 200% when set. Negligible difference when not set.

```ruby
require 'benchmark/ips'

class FakeMethod
  attr_reader :parameters

  def initialize(params)
    @parameters = [params]
  end
end

METHODS = [
  FakeMethod.new([nil, nil]),
  FakeMethod.new([nil, :test]),
  FakeMethod.new([nil, nil]),
  FakeMethod.new([nil, :function_here]),
  FakeMethod.new([nil, :__spy_args_1234567890]),
  FakeMethod.new([nil, :function_here]),
  FakeMethod.new([nil, :__spy_args_12345214141]),
  FakeMethod.new([nil, :function_here]),
  FakeMethod.new([nil, :__spy_args_12345214141]),
]

SPY_ARGS_PREFIX='__spy_args_'.freeze

def original(method)
  return nil unless method.parameters[0].is_a?(Array)
  id = method.parameters[0][1].to_s.sub!(SPY_ARGS_PREFIX, '')
  id.to_i if id
end

def updated(method)
  return nil unless method.parameters[0].is_a?(Array) && (raw = method.parameters[0][1]).to_s.start_with?(SPY_ARGS_PREFIX)

  id = raw.to_s.partition(SPY_ARGS_PREFIX).last

  id.to_i if id
end

def updated_2(method)
  return nil unless method.parameters[0].is_a?(Array)

  raw_id = method.parameters[0][1]

  return nil if !raw_id || !raw_id.to_s.start_with?(SPY_ARGS_PREFIX)

  slice_length = raw_id.length - SPY_ARGS_PREFIX.length
  id = raw_id.slice(SPY_ARGS_PREFIX.length, slice_length)

  id.to_i if id
end

def updated_3(method)
  return nil unless method.parameters[0].is_a?(Array) && (raw_id = method.parameters[0][1])
  return nil unless raw_id.to_s.start_with?(SPY_ARGS_PREFIX)

  slice_length = raw_id.length - SPY_ARGS_PREFIX.length
  id = raw_id.slice(SPY_ARGS_PREFIX.length, slice_length)

  id.to_i if id
end

Benchmark.ips do |x|
  x.report("original") { METHODS.each { |method| original(method) } }
  x.report("updated") { METHODS.each { |method| updated(method) } }
  x.report("updated_2") { METHODS.each { |method| updated_2(method) } }
  x.report("updated_3") { METHODS.each { |method| updated_3(method) } }

  x.compare!
end
```

```bash
$ ruby spy_subroutine_optimizations.rb 
Warming up --------------------------------------
            original    11.707k i/100ms
             updated    18.730k i/100ms
           updated_2    24.166k i/100ms
Calculating -------------------------------------
            original    129.216k (±13.9%) i/s -    643.885k
             updated    212.121k (± 5.5%) i/s -      1.068M
           updated_2    288.034k (± 5.0%) i/s -      1.450M

Comparison:
           updated_2:   288034.5 i/s
             updated:   212121.3 i/s - 1.36x slower
            original:   129216.2 i/s - 2.23x slower

Just-Another-MacBook:benchmarks blakemesdag$ ruby spy_subroutine_optimizations.rb 
Warming up --------------------------------------
            original    11.730k i/100ms
             updated    18.245k i/100ms
           updated_2    22.484k i/100ms
           updated_3    23.664k i/100ms
Calculating -------------------------------------
            original    126.847k (±14.6%) i/s -    621.690k
             updated    211.797k (± 6.0%) i/s -      1.058M
           updated_2    267.054k (± 4.2%) i/s -      1.349M
           updated_3    287.654k (± 4.9%) i/s -      1.444M

Comparison:
           updated_3:   287653.6 i/s
           updated_2:   267054.0 i/s - same-ish: difference falls within error
             updated:   211796.9 i/s - 1.36x slower
            original:   126846.9 i/s - 2.27x slower
```