### PR TITLE
and_raise should return self

### DIFF
--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -167,6 +167,7 @@ module Spy
       end
 
       @plan = Proc.new { raise exception }
+      self
     end
 
     # @overload and_throw(symbol)

--- a/test/spy/test_subroutine.rb
+++ b/test/spy/test_subroutine.rb
@@ -86,6 +86,18 @@ module Spy
       assert_equal result, @pen.write(nil)
     end
 
+    def test_spy_and_raise_raises_the_set_exception
+      pen_write_spy = spy_on(@pen, :write).and_raise(ArgumentError, "problems!")
+      assert_kind_of Subroutine, pen_write_spy
+      assert_equal [pen_write_spy], Agency.instance.spies
+
+      e = assert_raises ArgumentError do
+        @pen.write(nil)
+      end
+      assert_equal "problems!", e.message
+      assert pen_write_spy.has_been_called?
+    end
+
     def test_spy_and_return_can_call_a_block
       result = "hello world"
 


### PR DESCRIPTION
@ryanong the documentation for `.and_raise` claims that it will return `self`, but it currently doesn't. The current behaviour is also inconsistent with the other `.and_` methods. I couldn't find an existing test for `.and_raise`, so I added a new one based on the test for `.and_return`.
