### PR TITLE
Replace implicit Proc.new by explicit given block reference

### DIFF
--- a/lib/spy/api.rb
+++ b/lib/spy/api.rb
@@ -36,8 +36,8 @@ module Spy
         end
       end
 
-      def with(*args)
-        @with = block_given? ? Proc.new : args
+      def with(*args, &block)
+        @with = block_given? ? block : args
         self
       end
 

--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -111,7 +111,7 @@ module Spy
     #   spy.and_return(force: true) { |invalid_arity| true }
     #
     # @return [self]
-    def and_return(value = nil)
+    def and_return(value = nil, &block)
       @do_not_check_plan_arity = false
 
       if block_given?
@@ -121,7 +121,7 @@ module Spy
           raise ArgumentError, "value and block conflict. Choose one"
         end
 
-        @plan = Proc.new
+        @plan = block
         check_for_too_many_arguments!(@plan)
       else
         @plan = Proc.new { value }
@@ -215,9 +215,9 @@ module Spy
     # check if the method was called with the exact arguments
     # @param args Arguments that should have been sent to the method
     # @return [Boolean]
-    def has_been_called_with?(*args)
+    def has_been_called_with?(*args, &block)
       raise NeverHookedError unless @was_hooked
-      match = block_given? ? Proc.new : proc { |call| call.args == args }
+      match = block_given? ? block : proc { |call| call.args == args }
       calls.any?(&match)
     end
 


### PR DESCRIPTION
Fix the following warning introduced with Ruby 2.7

```
warning: Capturing the given block using Proc.new is deprecated; use `&block` instead
```