### PR TITLE
Fix private method call errors for older ruby versions

### DIFF
--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -58,14 +58,14 @@ module Spy
 
       if singleton_method
         if base_object.singleton_class.method_defined?(method_name) || base_object.singleton_class.private_method_defined?(method_name)
-          base_object.singleton_class.alias_method(method_name, method_name)
+          base_object.singleton_class.send(:alias_method, method_name, method_name)
         end
         base_object.define_singleton_method(method_name, override_method)
       else
         if base_object.method_defined?(method_name) || base_object.private_method_defined?(method_name)
-          base_object.alias_method(method_name, method_name)
+          base_object.send(:alias_method, method_name, method_name)
         end
-        base_object.define_method(method_name, override_method)
+        base_object.send(:define_method, method_name, override_method)
       end
 
       if [:public, :protected, :private].include? hook_opts[:visibility]


### PR DESCRIPTION
## Problem

I started seeing ```NoMethodError: private method `alias_method' called for ``` errors on tests run on ruby 2.4 that were coming from spy.  It looks like this was introduced in the `1.0.1` release which still the required ruby version is `>= 2.1.0`.  I checked spy's CI for that release and it has that failure too (https://travis-ci.org/github/ryanong/spy/builds/719648100)

## Solution

Use `send` to call these methods for compatibility with older ruby versions.