### PR TITLE
Spy.on_instance_method and and_call_through on #to_ary-able class causes an error

### DIFF
--- a/test/spy/test_subroutine.rb
+++ b/test/spy/test_subroutine.rb
@@ -6,6 +6,10 @@ module Spy
       Subroutine.new(base_object, method_name).hook
     end
 
+    def spy_on_instance_method(base_object, method_name)
+      Subroutine.new(base_object, method_name, false).hook
+    end
+
     def setup
       @pen = Pen.new
     end
@@ -135,6 +139,52 @@ module Spy
         string
       end
       assert_equal string, result
+    end
+
+    def test_spy_and_call_through_returns_original_method_result
+      string = "hello world"
+
+      write_spy = spy_on(@pen, :write).and_call_through
+      another_spy = spy_on(@pen, :another).and_call_through
+
+      result = @pen.write(string)
+
+      assert_equal string, result
+      assert write_spy.has_been_called?
+      assert_equal 'another', @pen.another
+      assert another_spy.has_been_called?
+    end
+
+    def test_spy_on_instance_and_call_through_returns_original_method_result
+      string = "hello world"
+
+      inst_write_spy = spy_on_instance_method(Pen, :write).and_call_through
+      inst_another_spy = spy_on_instance_method(Pen, :another).and_call_through
+
+      result = @pen.write(string)
+
+      assert_equal string, result
+      assert inst_write_spy.has_been_called?
+      assert_equal 'another', @pen.another
+      assert inst_another_spy.has_been_called?
+    end
+
+    def test_spy_on_instance_and_call_through_to_aryable
+      to_aryable = Class.new do
+        def hello
+          'hello'
+        end
+
+        def to_ary
+          [1]
+        end
+      end
+
+      inst_hello_spy = spy_on_instance_method(to_aryable, :hello).and_call_through
+      inst = to_aryable.new
+
+      assert_equal 'hello', inst.hello
+      assert inst_hello_spy.has_been_called?
     end
 
     def test_spy_hook_records_number_of_calls


### PR DESCRIPTION
Fixed a bug occurs when:

- use Spy.on_instance_method
- use #and_call_through
- hooked method is called without arguments

**Reproduce**

```rb
class ToAryableClass
  def hello
    'hello'
  end

  def to_ary
    [1, 2, 3]
  end
end

Spy.on_instance_method(ToAryableClass, :hello).and_call_through

inst = ToAryableClass.new
inst.hello

# TypeError: bind argument must be an instance of ToAryableClass
#   /**/lib/spy/subroutine.rb:155:in `bind'
#   /**/lib/spy/subroutine.rb:155:in `block in and_call_through'
#   /**/lib/spy/subroutine.rb:238:in `invoke'
#   /**/lib/spy/subroutine.rb:268:in `block in override_method'
#   /**/test/spy/test_subroutine.rb:159:in `test_spy_and_return_to_ary_safe'
```

The root cause is that arguments of #invoke `*args, &block` is passed to `@plan` proc with object unshifted: `object, *args, &block`.
When the `args` is empty and `object` has #to_ary, proc tries to destruct `object` into its arguments implicitly. This leads the first argument `object` of proc to be the first element of #to_ary result.

```rb
# with one or more args:
(proc { |obj, *args| obj }).call([1, 2], :a1, :a2)
=> [1, 2]

# with no args, it behaves like: obj, *args = [1, 2].to_ary
(proc { |obj, *args| obj }).call([1, 2])
=> 1
```

NOTE: Potentially `and_return { |obj, *args| .. }` also leads the same bug since `@plan` is used, but not changed yet.