### PR TITLE
Fix subroutine call with hash as last arg

### DIFF
--- a/lib/spy/version.rb
+++ b/lib/spy/version.rb
@@ -1,3 +1,3 @@
 module Spy
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/test/spy/test_subroutine.rb
+++ b/test/spy/test_subroutine.rb
@@ -113,6 +113,15 @@ module Spy
       assert_empty @pen.written
     end
 
+    def test_spy_and_return_can_call_a_block_with_hash
+      result = "hello world"
+
+      spy_on(@pen, :write_hash).and_return { |**opts| opts[:test] }
+
+      assert_equal result, @pen.write_hash(test: result)
+      assert_empty @pen.written
+    end
+
     def test_spy_and_return_can_call_a_block_raises_when_there_is_an_arity_mismatch
       write_spy = spy_on(@pen, :write)
       write_spy.and_return do |*args|
@@ -155,6 +164,16 @@ module Spy
       assert another_spy.has_been_called?
     end
 
+    def test_spy_and_call_through_with_hash_original_method
+      string = 'test:hello world'
+
+      write_spy = spy_on(@pen, :write_hash).and_call_through
+
+      @pen.write_hash(test: 'hello world')
+      assert_equal string, @pen.written.last
+      assert write_spy.has_been_called?
+    end
+
     def test_spy_on_instance_and_call_through_returns_original_method_result
       string = "hello world"
 
@@ -167,6 +186,17 @@ module Spy
       assert inst_write_spy.has_been_called?
       assert_equal 'another', @pen.another
       assert inst_another_spy.has_been_called?
+    end
+
+    def test_spy_on_instance_and_call_through_with_hash
+      string = 'test:hello world'
+
+      inst_write_spy = spy_on_instance_method(Pen, :write_hash).and_call_through
+
+      @pen.write_hash(test: 'hello world')
+
+      assert_equal string, @pen.written.last
+      assert inst_write_spy.has_been_called?
     end
 
     def test_spy_on_instance_and_call_through_to_aryable

--- a/test/support/pen.rb
+++ b/test/support/pen.rb
@@ -27,6 +27,12 @@ class Pen
     end
   end
 
+  def write_hash(**params)
+    params.each do |p|
+      write(p.join(':'))
+    end
+  end
+
   def greet(hello = "hello", name)
     write("#{hello} #{name}")
   end


### PR DESCRIPTION
Ruby 3 disallows passing a hash as last argument for methods with a double-splat parameter (`def example(arg1, **params)`).
It breaks tests when using spy to mock and call such methods because spy passes args linearly.

This update adds a check when using `Spy::Subroutine#invoke` if the last element in args is a Hash (using instance_of? to avoid matching other kind of hashes, such as HashWithIndifferentAccess), then pass this hash using double-splat to avoid an `ArgumentError` exception in Ruby 3, or a deprecation warning in Ruby >= 2.7.