### PR TITLE
Re-enable Spy for module_function

### DIFF
--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -84,7 +84,7 @@ module Spy
       raise NeverHookedError, "'#{method_name}' method has not been hooked" unless hooked?
 
       method_owner.send(:remove_method, method_name)
-      if original_method && method_owner == original_method.owner
+      if original_method #&& method_owner == original_method.owner
         original_method.owner.send(:define_method, method_name, original_method)
         original_method.owner.send(original_method_visibility, method_name) if original_method_visibility
       end

--- a/test/spy/test_unhook.rb
+++ b/test/spy/test_unhook.rb
@@ -1,0 +1,76 @@
+require 'test_helper'
+
+module Spy
+  class TestUnhook < Minitest::Test
+    module ModuleFunctionStyle
+      extend self
+
+      def hello
+        'hello world'
+      end
+    end
+
+    module Injected
+      def hello
+        'hello world'
+      end
+    end
+
+    class ModuleInjectedStyle
+      include Injected
+    end
+
+    class ModuleExtendedStyle
+      extend Injected
+    end
+
+    class SingletonMethodStyle
+      def self.hello
+        'hello world'
+      end
+    end
+
+    class InstanceMethodStyle
+      def hello
+        'hello world'
+      end
+    end
+
+    def test_ModuleFunctionStyle
+      spy = Spy.on(ModuleFunctionStyle, :hello).and_return('yo')
+      assert_equal ModuleFunctionStyle.hello, 'yo'
+      spy.unhook
+      assert_equal ModuleFunctionStyle.hello, 'hello world'
+    end
+
+    def test_ModuleInjectedStyle
+      instance = ModuleInjectedStyle.new
+      spy = Spy.on(instance, :hello).and_return('yo')
+      assert_equal instance.hello, 'yo'
+      spy.unhook
+      assert_equal instance.hello, 'hello world'
+    end
+
+    def test_ModuleExtendedStyle
+      spy = Spy.on(ModuleExtendedStyle, :hello).and_return('yo')
+      assert_equal ModuleExtendedStyle.hello, 'yo'
+      spy.unhook
+      assert_equal ModuleExtendedStyle.hello, 'hello world'
+    end
+
+    def test_SingletonMethodStyle
+      spy = Spy.on(SingletonMethodStyle, :hello).and_return('yo')
+      assert_equal SingletonMethodStyle.hello, 'yo'
+      spy.unhook
+      assert_equal SingletonMethodStyle.hello, 'hello world'
+    end
+
+    def test_InstanceMethodStyle
+      instance = InstanceMethodStyle.new
+      spy = Spy.on(instance, :hello).and_return('yo')
+      assert_equal instance.hello, 'yo'
+      spy.unhook
+      assert_equal instance.hello, 'hello world'
+    end
+  end
+end


### PR DESCRIPTION
After Spy 1.0.0 ruby written in module_function style stopped
working due to a mismatch between the module and the lambda's owner,
an anonymous class version of the module. This PR adds tests for this
situation and comments out a line of code that forced this comparison.