### PR TITLE
Fix and_return on class method

### DIFF
--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -217,11 +217,7 @@ module Spy
           call_plan(build_call_through_plan(object), block, *args)
         elsif @plan
           check_for_too_many_arguments!(@plan)
-          if base_object.is_a? Class
-            call_plan(@plan, block, object, *args)
-          else
-            call_plan(@plan, block, *args)
-          end
+          call_plan(@plan, block, *args)
         end
     ensure
       calls << CallLog.new(object, called_from, args, block, result)

--- a/test/integration/test_class_method.rb
+++ b/test/integration/test_class_method.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class TestClassMethod < Minitest::Test
+  def teardown
+    Spy::Agency.instance.dissolve!
+  end
+
+  def test_and_return
+    klass = Class.new do
+      def self.class_method(*args, &block)
+      end
+    end
+    received_args = nil
+    received_block = nil
+    Spy.on(klass, :class_method).and_return do |*args, &block|
+      received_args = args
+      received_block = block
+    end
+    block = -> {}
+    klass.class_method(:a, :b, &block)
+    assert_equal [:a, :b], received_args
+    assert_equal block, received_block
+  end
+end


### PR DESCRIPTION
Fixes #27.

The extra `object` argument to the plan was added in 874c91d0879a1a1f2c31f4bcca70ea961e5ecbad for `and_call_through`, but `and_call_through` has since been refactored and has a separate code path (`if @call_through`).