### PR TITLE
Hash as argument got turned into keyword arguments

### DIFF
--- a/lib/spy/call_log.rb
+++ b/lib/spy/call_log.rb
@@ -10,6 +10,9 @@ module Spy
     # @!attribute [r] args
     #   @return [Array] arguments were sent to the method
     #
+    # @!attribute [r] kwargs
+    #   @return [Array] keyword arguments were sent to the method
+    #
     # @!attribute [r] block
     #   @return [Proc] the block that was sent to the method
     #
@@ -17,10 +20,10 @@ module Spy
     #   @return The result of the method of being stubbed, or called through
 
 
-    attr_reader :object, :called_from, :args, :block, :result
+    attr_reader :object, :called_from, :args, :kwargs, :block, :result
 
-    def initialize(object, called_from, args, block, result)
-      @object, @called_from, @args, @block, @result = object, called_from, args, block, result
+    def initialize(object, called_from, args, kwargs, block, result)
+      @object, @called_from, @args, @kwargs, @block, @result = object, called_from, args, kwargs, block, result
     end
   end
 end

--- a/lib/spy/subroutine.rb
+++ b/lib/spy/subroutine.rb
@@ -201,9 +201,9 @@ module Spy
     # check if the method was called with the exact arguments
     # @param args Arguments that should have been sent to the method
     # @return [Boolean]
-    def has_been_called_with?(*args, &block)
+    def has_been_called_with?(*args, **kwargs, &block)
       raise NeverHookedError unless @was_hooked
-      match = block_given? ? block : proc { |call| call.args == args }
+      match = block_given? ? block : proc { |call| call.args == args && call.kwargs == kwargs }
       calls.any?(&match)
     end
 
@@ -222,7 +222,7 @@ module Spy
           call_plan(@plan, block, *args, **kwargs)
         end
     ensure
-      calls << CallLog.new(object, called_from, args, block, result)
+      calls << CallLog.new(object, called_from, args, kwargs, block, result)
     end
 
     # reset the call log

--- a/test/spy/test_subroutine.rb
+++ b/test/spy/test_subroutine.rb
@@ -150,6 +150,14 @@ module Spy
       assert_equal string, result
     end
 
+    def test_spy_and_call_through_with_hash_and_keyword_args
+      spy_on(@pen, 'hash_and_keyword_arg').and_call_through
+      hsh = { hello: 'world' }
+
+      assert_equal [hsh, nil], @pen.hash_and_keyword_arg(hsh)
+      assert_equal [hsh, 'foo'], @pen.hash_and_keyword_arg(hsh, keyword: 'foo')
+    end
+
     def test_spy_and_call_through_returns_original_method_result
       string = "hello world"
 

--- a/test/spy/test_subroutine.rb
+++ b/test/spy/test_subroutine.rb
@@ -245,6 +245,20 @@ module Spy
       assert pen_write_spy.has_been_called_with?("hello")
     end
 
+    def test_has_been_called_with_kwargs
+      pen_write_spy = spy_on(@pen, :opt_kwargs)
+      refute pen_write_spy.has_been_called_with?("hello")
+
+      @pen.opt_kwargs("hello")
+      assert pen_write_spy.has_been_called_with?("hello")
+
+      @pen.opt_kwargs("world", opt: "hello")
+      assert pen_write_spy.has_been_called_with?("world", opt: "hello")
+
+      @pen.opt_kwargs("hello world", opt: "world", opt2: "hello")
+      assert pen_write_spy.has_been_called_with?("hello world", opt: "world", opt2: "hello")
+    end
+
     def test_spy_hook_records_number_of_calls2
       args = ["hello world"]
       block = Proc.new {}

--- a/test/support/pen.rb
+++ b/test/support/pen.rb
@@ -37,6 +37,10 @@ class Pen
     write("#{hello} #{name}")
   end
 
+  def hash_and_keyword_arg(hsh, keyword: nil)
+    [hsh, keyword]
+  end
+
   def public_method
   end
 


### PR DESCRIPTION
When using `and_call_through` we had the problem passing a hash as argument to a function that also had optional keyword arguments it resolved into an `ArgumentError: wrong number of arguments (given 0, expected 1)`.

Example:

```ruby
module Foo
  def do_something(hsh, name: nil)
    hsh.keys
  end
end

Foo.do_something({ foo: 'bar' })
# => [:foo]

Spy.on(Foo, :do_something).and_call_through
Foo.do_something({ foo: 'bar' })
# => ArgumentError
```

