### PR TITLE
Fix CHANGELOG entry for 1.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Spy 1.0.4 (December 21th, 2022) ##
+## Spy 1.0.5 (December 25th, 2022) ##
 
 * remove usage of #present? (@ryanong)
 


### PR DESCRIPTION
Quick update to fix the changelog for version 1.0.5.

Grabbed the date from the tag here: https://github.com/ryanong/spy/releases/tag/v1.0.5.

<img width="384" alt="Screenshot 2023-01-03 at 13 37 02" src="https://user-images.githubusercontent.com/1557529/210300773-a267c1ba-eafc-468e-8c74-467575f3b660.png">